### PR TITLE
Fix throw not being respected on Malformed URL

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -90,7 +90,10 @@ func (h *HTTP) Options(ctx context.Context, url goja.Value, args ...goja.Value) 
 // taking goja.Values as arguments
 func (h *HTTP) Request(ctx context.Context, method string, url goja.Value, args ...goja.Value) (*Response, error) {
 	state := lib.GetState(ctx)
-	throw := state.Options.Throw.Bool
+	var throw bool
+	if state != nil {
+		throw = state.Options.Throw.Bool
+	}
 	u, err := ToURL(url)
 	if err != nil {
 		if throw {

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -89,9 +89,17 @@ func (h *HTTP) Options(ctx context.Context, url goja.Value, args ...goja.Value) 
 // Request makes an http request of the provided `method` and returns a corresponding response by
 // taking goja.Values as arguments
 func (h *HTTP) Request(ctx context.Context, method string, url goja.Value, args ...goja.Value) (*Response, error) {
+	state := lib.GetState(ctx)
+	throw := state.Options.Throw.Bool
 	u, err := ToURL(url)
 	if err != nil {
-		return nil, err
+		if throw {
+			return nil, err
+		}
+		state.Logger.WithField("error", err).Warn("Request Failed")
+		return &Response{
+			Response: &httpext.Response{},
+		}, nil
 	}
 
 	var body interface{}


### PR DESCRIPTION
Closes #1502

Notes:
* Not sure if the verification should happen on Request()
* The way throw is disabled on the test feels clunky, it might be a better approach
