### PR TITLE
Improve the validation of ramping-vus executor's options

### DIFF
--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -201,7 +201,7 @@ var configMapTestCases = []configMapTestCase{
 			assert.Equal(t, uint64(11), lib.GetMaxPossibleVUs(schedReqs))
 		}},
 	},
-	{`{"varloops": {"executor": "ramping-vus", "startVUs": 0, "stages": [{"duration": "60s", "target": 0}]}}`, exp{}},
+	{`{"varloops": {"executor": "ramping-vus", "startVUs": 0, "stages": [{"duration": "60s", "target": 0}]}}`, exp{validationError: true}},
 	{`{"varloops": {"executor": "ramping-vus", "startVUs": -1, "stages": [{"duration": "60s", "target": 30}]}}`, exp{validationError: true}},
 	{`{"varloops": {"executor": "ramping-vus", "startVUs": 2, "stages": [{"duration": "-60s", "target": 30}]}}`, exp{validationError: true}},
 	{`{"varloops": {"executor": "ramping-vus", "startVUs": 2, "stages": [{"duration": "60s", "target": -30}]}}`, exp{validationError: true}},

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -102,6 +102,10 @@ func (vlvc RampingVUsConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("the number of start VUs shouldn't be negative"))
 	}
 
+	if getStagesUnscaledMaxTarget(vlvc.StartVUs.Int64, vlvc.Stages) <= 0 {
+		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target value should be greater than 0"))
+	}
+
 	return append(errors, validateStages(vlvc.Stages)...)
 }
 

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -38,6 +38,26 @@ import (
 	"github.com/loadimpact/k6/lib/types"
 )
 
+func TestRampingVUsConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	errs := NewRampingVUsConfig("default").Validate()
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "one stage has to be specified")
+
+	c := NewRampingVUsConfig("stage")
+	c.Stages = []Stage{
+		{Target: null.IntFrom(0), Duration: types.NullDurationFrom(12 * time.Second)},
+	}
+	errs = c.Validate()
+	require.Empty(t, errs) // by default StartVUs is 1
+
+	c.StartVUs = null.IntFrom(0)
+	errs = c.Validate()
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "greater than 0")
+}
+
 func TestRampingVUsRun(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Previously, this script would have run without an error, though also without actually doing anything :sweat_smile: 
```js
import http from 'k6/http';
export const options = {
    vus: 0,
    stages: [
        { duration: '12s', target: 0 },
    ],
};
export default function () {
    http.get('https://test.k6.io')
}
```

Now users will see a nice validation error like this:
```
ERRO[0000] There were problems with the specified script configuration:
	- scenario default has configuration errors: either startVUs or one of the stages' target value should be greater than 0 
```