### PR TITLE
Update golangci-lint to v1.39.0

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -37,7 +37,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-        GOLANGCI_VERSION: v1.31
+        GOLANG_CI_VERSION: "1.39.0"
         GO111MODULE: 'on'
     steps:
       - name: Checkout code
@@ -50,7 +50,7 @@ jobs:
           go-version: 1.16.x
       - name: Install golangci-lint
         working-directory: /tmp
-        run: go get github.com/golangci/golangci-lint/cmd/golangci-lint@$GOLANGCI_VERSION
+        run: go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANG_CI_VERSION"
       - name: Run linters
         run: |
           BASEREV=$(git merge-base HEAD origin/master)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+  - nlreturn
   - gci
   - gochecknoinits
   - godot
@@ -67,6 +68,10 @@ linters:
   - wsl
   - gomnd
   - goerr113 # most of the errors here are meant for humans
-  - nlreturn
   - goheader
+  - exhaustivestruct
+  - thelper
+  - maligned # replaced by govet 'fieldalignment'
+  - interfacer # deprecated
+  - scopelint # deprecated, replaced by exportloopref
   fast: false


### PR DESCRIPTION
Might be a good idea to go through the complete list of current linter issues and try to prune certain classes of the most common errors we have. For example, disabling certain linters in tests, or in go-generated files, `gofumpt`-ing the whole codebase, etc. 