### PR TITLE
Fix a data race and double-counting of active VUs in arrival-rate executors

### DIFF
--- a/lib/execution.go
+++ b/lib/execution.go
@@ -558,7 +558,8 @@ func (es *ExecutionState) SetInitVUFunc(initVUFunc InitVUFunc) {
 
 // GetUnplannedVU checks if any unplanned VUs remain to be initialized, and if
 // they do, it initializes one and returns it. If all unplanned VUs have already
-// been initialized, it returns one from the global vus buffer.
+// been initialized, it returns one from the global vus buffer, but doesn't
+// automatically increment the active VUs counter in either case.
 //
 // IMPORTANT: GetUnplannedVU() doesn't do any checking if the requesting
 // executor is actually allowed to have the VU at this particular time.
@@ -570,7 +571,7 @@ func (es *ExecutionState) GetUnplannedVU(ctx context.Context, logger *logrus.Ent
 	if remVUs < 0 {
 		logger.Debug("Reusing a previously initialized unplanned VU")
 		atomic.AddInt64(es.uninitializedUnplannedVUs, 1)
-		return es.GetPlannedVU(logger, true)
+		return es.GetPlannedVU(logger, false)
 	}
 
 	logger.Debug("Initializing an unplanned VU, this may affect test results")

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -241,14 +241,13 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 	activeVUs := make(chan lib.ActiveVU, maxVUs)
 	activeVUsCount := uint64(0)
 
-	activationParams := getVUActivationParams(maxDurationCtx, car.config.BaseConfig,
-		func(u lib.InitializedVU) {
-			car.executionState.ReturnVU(u, true)
-			activeVUsWg.Done()
-		})
+	returnVU := func(u lib.InitializedVU) {
+		car.executionState.ReturnVU(u, true)
+		activeVUsWg.Done()
+	}
 	activateVU := func(initVU lib.InitializedVU) lib.ActiveVU {
 		activeVUsWg.Add(1)
-		activeVU := initVU.Activate(activationParams)
+		activeVU := initVU.Activate(getVUActivationParams(maxDurationCtx, car.config.BaseConfig, returnVU))
 		car.executionState.ModCurrentlyActiveVUsCount(+1)
 		atomic.AddUint64(&activeVUsCount, 1)
 		return activeVU


### PR DESCRIPTION
Closes https://github.com/k6io/k6/issues/1954 and fixes https://github.com/k6io/k6/issues/1657
