### PR TITLE
ramping-arrival-rate: Avoid to spawn a new goroutine for every iteration

### DIFF
--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -42,7 +42,7 @@ func simpleRunner(vuFn func(context.Context) error) lib.Runner {
 	}
 }
 
-func setupExecutor(t *testing.T, config lib.ExecutorConfig, es *lib.ExecutionState, runner lib.Runner) (
+func setupExecutor(t testing.TB, config lib.ExecutorConfig, es *lib.ExecutionState, runner lib.Runner) (
 	context.Context, context.CancelFunc, lib.Executor, *testutils.SimpleLogrusHook,
 ) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -479,8 +479,8 @@ func newActiveVUPool() *activeVUPool {
 	}
 }
 
-// Run invokes a request to execute a new iteration.
-// When there aren'p *available VUs to process the request
+// TryRunIteration invokes a request to execute a new iteration.
+// When there are no available VUs to process the request
 // then false is returned.
 func (p *activeVUPool) TryRunIteration() bool {
 	select {
@@ -512,7 +512,7 @@ func (p *activeVUPool) AddVU(ctx context.Context, avu lib.ActiveVU, runfn func(c
 }
 
 // Close stops the pool from accepting requests
-// then it will wait thap *all the on-going iterations will be completed.
+// then it will wait for all on-going iterations to complete.
 func (p *activeVUPool) Close() {
 	close(p.iterations)
 	p.wg.Wait()

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -316,25 +316,32 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 	returnedVUs := make(chan struct{})
 	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
 
+	vusPool := newActiveVUPool()
+
 	defer func() {
+		vusPool.Close()
 		// Make sure all VUs aren't executing iterations anymore, for the cancel()
 		// below to deactivate them.
 		<-returnedVUs
 		cancel()
 		activeVUsWg.Wait()
 	}()
-	activeVUs := make(chan lib.ActiveVU, maxVUs)
+
 	activeVUsCount := uint64(0)
 
 	returnVU := func(u lib.InitializedVU) {
 		varr.executionState.ReturnVU(u, true)
 		activeVUsWg.Done()
 	}
+
+	runIterationBasic := getIterationRunner(varr.executionState, varr.logger)
 	activateVU := func(initVU lib.InitializedVU) lib.ActiveVU {
 		activeVUsWg.Add(1)
 		activeVU := initVU.Activate(getVUActivationParams(maxDurationCtx, varr.config.BaseConfig, returnVU))
 		varr.executionState.ModCurrentlyActiveVUsCount(+1)
 		atomic.AddUint64(&activeVUsCount, 1)
+
+		vusPool.AddVU(maxDurationCtx, activeVU, runIterationBasic)
 		return activeVU
 	}
 
@@ -343,13 +350,7 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 	defer close(makeUnplannedVUCh)
 	go func() {
 		defer close(returnedVUs)
-		defer func() {
-			// this is done here as to not have an unplannedVU in the middle of initialization when
-			// starting to return activeVUs
-			for i := uint64(0); i < atomic.LoadUint64(&activeVUsCount); i++ {
-				<-activeVUs
-			}
-		}()
+
 		for range makeUnplannedVUCh {
 			varr.logger.Debug("Starting initialization of an unplanned VU...")
 			initVU, err := varr.executionState.GetUnplannedVU(maxDurationCtx, varr.logger)
@@ -358,7 +359,7 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 				varr.logger.WithError(err).Error("Error while allocating unplanned VU")
 			} else {
 				varr.logger.Debug("The unplanned VU finished initializing successfully!")
-				activeVUs <- activateVU(initVU)
+				activateVU(initVU)
 			}
 		}
 	}()
@@ -369,7 +370,7 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 		if err != nil {
 			return err
 		}
-		activeVUs <- activateVU(initVU)
+		activateVU(initVU)
 	}
 
 	tickerPeriod := int64(startTickerPeriod.Duration)
@@ -380,9 +381,8 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 	progressFn := func() (float64, []string) {
 		currActiveVUs := atomic.LoadUint64(&activeVUsCount)
 		currentTickerPeriod := atomic.LoadInt64(&tickerPeriod)
-		vusInBuffer := uint64(len(activeVUs))
 		progVUs := fmt.Sprintf(vusFmt+"/"+vusFmt+" VUs",
-			currActiveVUs-vusInBuffer, currActiveVUs)
+			vusPool.Running(), currActiveVUs)
 
 		itersPerSec := 0.0
 		if currentTickerPeriod > 0 {
@@ -408,12 +408,6 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 	go trackProgress(parentCtx, maxDurationCtx, regDurationCtx, varr, progressFn)
 
 	regDurationDone := regDurationCtx.Done()
-	runIterationBasic := getIterationRunner(varr.executionState, varr.logger)
-	runIteration := func(vu lib.ActiveVU) {
-		runIterationBasic(maxDurationCtx, vu)
-		activeVUs <- vu
-	}
-
 	timer := time.NewTimer(time.Hour)
 	start := time.Now()
 	ch := make(chan time.Duration, 10) // buffer 10 iteration times ahead
@@ -439,12 +433,10 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 			}
 		}
 
-		select {
-		case vu := <-activeVUs: // ideally, we get the VU from the buffer without any issues
-			go runIteration(vu) //TODO: refactor so we dont spin up a goroutine for each iteration
+		if vusPool.TryRunIteration() {
 			continue
-		default: // no free VUs currently available
 		}
+
 		// Since there aren't any free VUs available, consider this iteration
 		// dropped - we aren't going to try to recover it, but
 
@@ -470,4 +462,58 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- stats.S
 		}
 	}
 	return nil
+}
+
+// activeVUPool controls the activeVUs
+// executing the received requests for iterations.
+type activeVUPool struct {
+	iterations chan struct{}
+	running    uint64
+	wg         sync.WaitGroup
+}
+
+// newActiveVUPool returns an activeVUPool.
+func newActiveVUPool() *activeVUPool {
+	return &activeVUPool{
+		iterations: make(chan struct{}),
+	}
+}
+
+// Run invokes a request to execute a new iteration.
+// When there aren'p *available VUs to process the request
+// then false is returned.
+func (p *activeVUPool) TryRunIteration() bool {
+	select {
+	case p.iterations <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Running returns the number of the currently running VUs.
+func (p *activeVUPool) Running() uint64 {
+	return atomic.LoadUint64(&p.running)
+}
+
+// AddVU adds the active VU to the pool of VUs for handling the incoming requests.
+// When a new request is accepted the runfn function is executed.
+func (p *activeVUPool) AddVU(ctx context.Context, avu lib.ActiveVU, runfn func(context.Context, lib.ActiveVU) bool) {
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+
+		for range p.iterations {
+			atomic.AddUint64(&p.running, uint64(1))
+			runfn(ctx, avu)
+			atomic.AddUint64(&p.running, ^uint64(0))
+		}
+	}()
+}
+
+// Close stops the pool from accepting requests
+// then it will wait thap *all the on-going iterations will be completed.
+func (p *activeVUPool) Close() {
+	close(p.iterations)
+	p.wg.Wait()
 }


### PR DESCRIPTION
Switched the `ramping-arrival-rate` from goroutine per iteration to goroutine per VU.
Refactor the Run method is not part of this PR, it is scheduled for the original issue, so I tried to impact in a minimal way the code.

However, the main issue in terms of performance was already resolved from #1955 as the following tests should assert:

using this config:

```
exports.options = {
    scenarios: {
        test1: {
            executor: 'ramping-arrival-rate',
            preAllocatedVUs: 1000,
            stages:[
                {target:100000, duration:'0s'},
                {target:100000, duration:'15s'},
            ],
        },
    },
};

exports.default =  function () {}
```

result with v0.31.1 still affected by the problem:
```
$ docker run -v $PWD:/home/k6 -i loadimpact/k6:0.31.1 run - <script.js

iterations...........: 200591 13368.444337/s
```
and the result with master
```
$ docker run -v $PWD:/home/k6 -i loadimpact/k6:master run - <script.js

iterations...........: 1499214 99925.899592/s
```

Closes #1944

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/loadimpact/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
