### PR TITLE
Build latest k6packager, fix image tagging

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -12,18 +12,19 @@ defaults:
 jobs:
   publish-packager:
     runs-on: ubuntu-latest
-    env:
-      VERSION: 0.0.1
-      AWSCLI_VERSION: 2.1.36
-      DOCKER_IMAGE_ID: k6io/k6packager
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build
+        env:
+          AWSCLI_VERSION: 2.1.36
         run: |
           cd packaging
           docker-compose build packager
       - name: Publish
+        env:
+          VERSION: 0.0.1
+          DOCKER_IMAGE_ID: k6io/k6packager
         run: |
           echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/${DOCKER_IMAGE_ID}:${VERSION}"


### PR DESCRIPTION
Setting VERSION for the build step makes things difficult for pushing, so build `latest` locally and tag it for pushing only.

This should fix https://github.com/k6io/k6/runs/2322019274.