### PR TITLE
Package repository tweaks

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -407,7 +407,7 @@ jobs:
           cat > packaging/.env <<EOF
           AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION=eu-west-1
+          AWS_DEFAULT_REGION=us-east-1
           AWS_CF_DISTRIBUTION="${{ secrets.AWS_CF_DISTRIBUTION }}"
           PGP_SIGN_KEY_PASSPHRASE=${{ secrets.PGP_SIGN_KEY_PASSPHRASE }}
           EOF

--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       VERSION: 0.0.1
       AWSCLI_VERSION: 2.1.36
+      S3CMD_VERSION: 2.1.0
       DOCKER_IMAGE_ID: ghcr.io/k6io/k6packager
     steps:
       - name: Checkout code

--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -13,7 +13,7 @@ jobs:
   publish-packager:
     runs-on: ubuntu-latest
     env:
-      VERSION: 0.0.1
+      VERSION: 0.0.2
       AWSCLI_VERSION: 2.1.36
       S3CMD_VERSION: 2.1.0
       DOCKER_IMAGE_ID: ghcr.io/k6io/k6packager

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,7 +5,9 @@ LABEL maintainer="k6 Developers <developers@k6.io>"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y apt-utils createrepo curl git gnupg2 python3 unzip
+    apt-get install -y apt-utils createrepo curl git gnupg2 python3-pip unzip
+
+RUN pip3 install s3cmd
 
 COPY ./awscli-key.gpg .
 

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -11,9 +11,7 @@ ARG S3CMD_VERSION
 RUN pip3 install "s3cmd${S3CMD_VERSION:+==$S3CMD_VERSION}"
 
 COPY ./awscli-key.gpg .
-
 ARG AWSCLI_VERSION
-
 # Download awscli, check GPG signature and install.
 RUN export GNUPGHOME="$(mktemp -d)" && \
     gpg2 --import ./awscli-key.gpg && \
@@ -34,5 +32,8 @@ COPY bin/ /usr/local/bin/
 
 USER k6
 WORKDIR /home/k6
+
+COPY --chown=k6:k6 ./k6-rpm-repo.spec rpmbuild/SPECS/
+COPY --chown=k6:k6 ./k6-rpm.repo rpmbuild/SOURCES/k6-io.repo
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install -y apt-utils createrepo curl git gnupg2 python3-pip unzip
 
-RUN pip3 install s3cmd
+ARG S3CMD_VERSION
+RUN pip3 install "s3cmd${S3CMD_VERSION:+==$S3CMD_VERSION}"
 
 COPY ./awscli-key.gpg .
 

--- a/packaging/bin/create-deb-repo.sh
+++ b/packaging/bin/create-deb-repo.sh
@@ -71,7 +71,7 @@ for arch in $architectures; do
     "s3://${S3PATH}/${bindir}/" "$bindir/"
 
   # Copy the new packages in
-  find "$PKGDIR" -name "*$arch*.deb" -type f -print0 | xargs -r0 cp -t "$bindir"
+  find "$PKGDIR" -name "*$arch*.deb" -type f -print0 | xargs -r0 cp -avt "$bindir"
   # Generate signatures for files that don't have it
   # TODO: Switch to debsign instead? This is currently done as Bintray did it,
   # but the signature is not validated by apt/dpkg.

--- a/packaging/bin/create-msi-repo.sh
+++ b/packaging/bin/create-msi-repo.sh
@@ -51,7 +51,7 @@ mkdir -p "$REPODIR"
 aws s3 sync --no-progress --exclude='*' --include='*.msi' "s3://${S3PATH}/" "$REPODIR/"
 
 # Copy the new packages in
-find "$PKGDIR" -name "*.msi" -type f -print0 | xargs -r0 cp -t "$REPODIR"
+find "$PKGDIR" -name "*.msi" -type f -print0 | xargs -r0 cp -avt "$REPODIR"
 
 delete_old_pkgs "$REPODIR"
 

--- a/packaging/bin/create-msi-repo.sh
+++ b/packaging/bin/create-msi-repo.sh
@@ -2,8 +2,8 @@
 set -eEuo pipefail
 
 # External dependencies:
-# - https://aws.amazon.com/cli/
-#   awscli expects AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set in the
+# - https://github.com/s3tools/s3cmd
+#   s3cmd expects AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set in the
 #   environment.
 # - generate_index.py
 #   For generating the index.html of each directory. It's available in the
@@ -27,20 +27,12 @@ delete_old_pkgs() {
 
 sync_to_s3() {
   log "Syncing to S3 ..."
-  aws s3 sync --no-progress --delete "${REPODIR}/" "s3://${S3PATH}/"
+  s3cmd sync --delete-removed "${REPODIR}/" "s3://${S3PATH}/"
 
   # Set a short cache expiration for index files and the latest MSI package.
-  aws s3 cp --no-progress --recursive --exclude='*' \
-    --include='*.html' \
-    --cache-control='max-age=60,must-revalidate' \
-    --content-type='text/html' \
-    --metadata-directive=REPLACE \
-    "s3://${S3PATH}" "s3://${S3PATH}"
-  aws s3 cp --no-progress \
-    --cache-control='max-age=60,must-revalidate' \
-    --content-type='application/x-msi' \
-    --metadata-directive=REPLACE \
-    "s3://${S3PATH}/k6-latest-amd64.msi" "s3://${S3PATH}/k6-latest-amd64.msi"
+  s3cmd modify --recursive --exclude='*' \
+    --include='index.html' --include='k6-latest-amd64.msi' \
+    --add-header='Cache-Control: max-age=60,must-revalidate' "s3://${S3PATH}/"
 }
 
 mkdir -p "$REPODIR"
@@ -48,7 +40,7 @@ mkdir -p "$REPODIR"
 # Download existing packages
 # For MSI packages this is only done to be able to generate the index.html correctly.
 # Should we fake it and create empty files that have the same timestamp and size as the original ones?
-aws s3 sync --no-progress --exclude='*' --include='*.msi' "s3://${S3PATH}/" "$REPODIR/"
+s3cmd sync --exclude='*' --include='*.msi' "s3://${S3PATH}/" "$REPODIR/"
 
 # Copy the new packages in
 find "$PKGDIR" -name "*.msi" -type f -print0 | xargs -r0 cp -avt "$REPODIR"

--- a/packaging/bin/entrypoint.sh
+++ b/packaging/bin/entrypoint.sh
@@ -48,6 +48,16 @@ for repo in deb rpm msi; do
   "create-${repo}-repo.sh" "$PWD/dist" "${pkgdir}/${repo}"
 done
 
+# Create and sync the RPM repository package if it doesn't exist already.
+# NOTE: `s3cmd info` requires GetPolicy AWS permissions, and `s3cmd ls`
+# exits with 0 for missing objects, so use awscli for this check.
+aws s3 ls "s3://${s3bucket}/rpm/repo.rpm" >/dev/null || {
+  mkdir -p "$HOME/rpmbuild/SOURCES"
+  cp -av "${pkgdir}/key.gpg" "$HOME/rpmbuild/SOURCES/RPM-GPG-KEY-k6-io"
+  rpmbuild -ba "$HOME/rpmbuild/SPECS/k6-rpm-repo.spec"
+  s3cmd put "$(find "$HOME/rpmbuild/RPMS/" -type f -name '*.rpm')" "s3://${s3bucket}/rpm/repo.rpm"
+}
+
 # Generate and sync the main index.html
 (cd "$pkgdir" && generate_index.py)
 s3cmd put --add-header='Cache-Control: max-age=60,must-revalidate' \

--- a/packaging/bin/entrypoint.sh
+++ b/packaging/bin/entrypoint.sh
@@ -42,10 +42,7 @@ done
 aws s3 cp --no-progress --cache-control='max-age=60,must-revalidate' \
   "${pkgdir}/index.html" "s3://${s3bucket}/index.html"
 
-# Invalidate CloudFront cache for index files, repo metadata and the latest MSI
-# package redirect.
-# TODO: Maybe just invalidate the entire bucket (/*), since CF charges per
-# invalidation path.
+# Invalidate CloudFront cache for index files, repo metadata and the latest MSI package.
 IFS=' ' read -ra indexes <<< \
   "$(find "${pkgdir}" -name 'index.html' -type f | sed "s:^${pkgdir}::" | sort | paste -sd' ')"
 aws cloudfront create-invalidation --distribution-id "$AWS_CF_DISTRIBUTION" \

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       args:
         - AWSCLI_VERSION=${AWSCLI_VERSION:-2.1.36}
+        - S3CMD_VERSION=${S3CMD_VERSION:-2.1.0}
     image: ghcr.io/k6io/k6packager:latest
     environment:
       - AWS_ACCESS_KEY_ID

--- a/packaging/k6-rpm-repo.spec
+++ b/packaging/k6-rpm-repo.spec
@@ -1,0 +1,37 @@
+Name:           k6-rpm
+Version:        0.0.1
+Release:        1
+Summary:        k6 RPM Repository Configuration
+Group:          System Environment/Base
+License:        AGPL-3.0
+URL:            https://dl.k6.io
+Source0:        RPM-GPG-KEY-k6-io
+Source1:        k6-io.repo
+BuildRoot:      %{_builddir}/%{name}-%{version}-rpmroot
+BuildArch:      noarch
+
+%description
+This package installs the repository GPG and repo files for the k6 software repository.
+
+%prep
+%setup -c -T
+
+%build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+# gpg
+install -Dpm 644 %{SOURCE0} $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-k6-io
+
+# yum
+install -dm 755 $RPM_BUILD_ROOT%{_sysconfdir}/yum.repos.d
+install -pm 644 %{SOURCE1} $RPM_BUILD_ROOT%{_sysconfdir}/yum.repos.d
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-k6-io
+%config %{_sysconfdir}/yum.repos.d/k6-io.repo

--- a/packaging/k6-rpm.repo
+++ b/packaging/k6-rpm.repo
@@ -1,0 +1,7 @@
+[k6]
+name=k6
+baseurl=https://dl.k6.io/rpm/$basearch
+enabled=1
+gpgcheck=1
+metadata_expire=1d
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-k6-io


### PR DESCRIPTION
These are a few changes I did while copying packages from Bintray to https://dl.k6.io/. The biggest one is the switch back to `s3cmd` for S3 operations since [aws-cli doesn't preserve timestamps when syncing with S3](https://github.com/aws/aws-cli/issues/3069#issuecomment-818732309), and s3cmd does this nicely with object metadata. It also has better mimetype detection and checks file equality with MD5 hashes instead of relying on file size or `mtime`. So now we use aws-cli only for CloudFront invalidation and s3cmd for everything else.

I'll leave the original WIP branch (`ci/populate-dl-k6-io`) unmerged, since it has the script to download from Bintray and some additional tweaks, in case we need it again soon, and we can delete it in a few weeks.