### PR TITLE
Make possible for the cloud output to stop the engine

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	PushRefID   null.String `json:"pushRefID" envconfig:"K6_CLOUD_PUSH_REF_ID"`
 	WebAppURL   null.String `json:"webAppURL" envconfig:"K6_CLOUD_WEB_APP_URL"`
 	NoCompress  null.Bool   `json:"noCompress" envconfig:"K6_CLOUD_NO_COMPRESS"`
+	StopOnError null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
 
 	MaxMetricSamplesPerPackage null.Int `json:"maxMetricSamplesPerPackage" envconfig:"K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE"`
 
@@ -208,6 +209,9 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.NoCompress.Valid {
 		c.NoCompress = cfg.NoCompress
+	}
+	if cfg.StopOnError.Valid {
+		c.StopOnError = cfg.StopOnError
 	}
 	if cfg.MaxMetricSamplesPerPackage.Valid {
 		c.MaxMetricSamplesPerPackage = cfg.MaxMetricSamplesPerPackage

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -48,6 +48,7 @@ func TestConfigApply(t *testing.T) {
 		PushRefID:                       null.NewString("PushRefID", true),
 		WebAppURL:                       null.NewString("foo", true),
 		NoCompress:                      null.NewBool(true, true),
+		StopOnError:                     null.NewBool(true, true),
 		MaxMetricSamplesPerPackage:      null.NewInt(2, true),
 		MetricPushInterval:              types.NewNullDuration(1*time.Second, true),
 		MetricPushConcurrency:           null.NewInt(3, true),

--- a/core/engine.go
+++ b/core/engine.go
@@ -138,8 +138,8 @@ func (e *Engine) StartOutputs() error {
 			thresholdOut.SetThresholds(e.thresholds)
 		}
 
-		if stopOut, ok := out.(output.WithStopRunWithError); ok {
-			stopOut.SetStopRunWithErrorFunc(
+		if stopOut, ok := out.(output.WithSetStopEngineRunWithError); ok {
+			stopOut.SetStopEngineRunWithError(
 				func(err error) {
 					e.logger.WithError(err).Error("Received error to stop from output")
 					// TODO don't stop if configured

--- a/core/engine.go
+++ b/core/engine.go
@@ -138,8 +138,8 @@ func (e *Engine) StartOutputs() error {
 			thresholdOut.SetThresholds(e.thresholds)
 		}
 
-		if stopOut, ok := out.(output.WithSetStopEngineRunWithError); ok {
-			stopOut.SetStopEngineRunWithError(
+		if stopOut, ok := out.(output.WithTestRunStop); ok {
+			stopOut.SetTestRunStopCallback(
 				func(err error) {
 					e.logger.WithError(err).Error("Received error to stop from output")
 					// TODO don't stop if configured

--- a/core/engine.go
+++ b/core/engine.go
@@ -142,7 +142,6 @@ func (e *Engine) StartOutputs() error {
 			stopOut.SetTestRunStopCallback(
 				func(err error) {
 					e.logger.WithError(err).Error("Received error to stop from output")
-					// TODO don't stop if configured
 					e.Stop()
 				})
 		}

--- a/core/engine.go
+++ b/core/engine.go
@@ -138,6 +138,15 @@ func (e *Engine) StartOutputs() error {
 			thresholdOut.SetThresholds(e.thresholds)
 		}
 
+		if thresholdOut, ok := out.(output.WithStopRunWithError); ok {
+			thresholdOut.SetStopRunWithErrorFunc(
+				func(err error) {
+					e.logger.WithError(err).Error("Received error to stop from output")
+					// TODO don't stop if configured
+					e.Stop()
+				})
+		}
+
 		if err := out.Start(); err != nil {
 			e.stopOutputs(i)
 			return err

--- a/core/engine.go
+++ b/core/engine.go
@@ -138,8 +138,8 @@ func (e *Engine) StartOutputs() error {
 			thresholdOut.SetThresholds(e.thresholds)
 		}
 
-		if thresholdOut, ok := out.(output.WithStopRunWithError); ok {
-			thresholdOut.SetStopRunWithErrorFunc(
+		if stopOut, ok := out.(output.WithStopRunWithError); ok {
+			stopOut.SetStopRunWithErrorFunc(
 				func(err error) {
 					e.logger.WithError(err).Error("Received error to stop from output")
 					// TODO don't stop if configured

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -324,7 +324,7 @@ func (out *Output) SetThresholds(scriptThresholds map[string]stats.Thresholds) {
 	out.thresholds = thresholds
 }
 
-// SetStopRunStopCallback receives the function that stops the engine on error
+// SetTestRunStopCallback receives the function that stops the engine on error
 func (out *Output) SetTestRunStopCallback(stopFunc func(error)) {
 	out.engineStopFunc = stopFunc
 }

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -87,7 +87,7 @@ type Output struct {
 var _ interface {
 	output.WithRunStatusUpdates
 	output.WithThresholds
-	output.WithStopRunWithError
+	output.WithSetStopEngineRunWithError
 } = &Output{}
 
 // New creates a new cloud output.
@@ -324,8 +324,8 @@ func (out *Output) SetThresholds(scriptThresholds map[string]stats.Thresholds) {
 	out.thresholds = thresholds
 }
 
-// SetStopRunWithErrorFunc receives the function that stops the engine on error
-func (out *Output) SetStopRunWithErrorFunc(stopFunc func(error)) {
+// SetStopEngineRunWithError receives the function that stops the engine on error
+func (out *Output) SetStopEngineRunWithError(stopFunc func(error)) {
 	out.engineStopFunc = stopFunc
 }
 

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -87,7 +87,7 @@ type Output struct {
 var _ interface {
 	output.WithRunStatusUpdates
 	output.WithThresholds
-	output.WithSetStopEngineRunWithError
+	output.WithTestRunStop
 } = &Output{}
 
 // New creates a new cloud output.
@@ -324,8 +324,8 @@ func (out *Output) SetThresholds(scriptThresholds map[string]stats.Thresholds) {
 	out.thresholds = thresholds
 }
 
-// SetStopEngineRunWithError receives the function that stops the engine on error
-func (out *Output) SetStopEngineRunWithError(stopFunc func(error)) {
+// SetStopRunStopCallback receives the function that stops the engine on error
+func (out *Output) SetTestRunStopCallback(stopFunc func(error)) {
 	out.engineStopFunc = stopFunc
 }
 

--- a/output/types.go
+++ b/output/types.go
@@ -80,9 +80,9 @@ type WithThresholds interface {
 	SetThresholds(map[string]stats.Thresholds)
 }
 
-// WithTestRunStop is an output that can stop the Engine mid-test, interrupting 
+// WithTestRunStop is an output that can stop the Engine mid-test, interrupting
 // the whole test run execution if some internal condition occurs, completely
-// independently from the thresholds. It requires a callback function which 
+// independently from the thresholds. It requires a callback function which
 // expects an error and triggers the Engine to stop.
 type WithTestRunStop interface {
 	Output

--- a/output/types.go
+++ b/output/types.go
@@ -80,8 +80,11 @@ type WithThresholds interface {
 	SetThresholds(map[string]stats.Thresholds)
 }
 
-// TODO: add some way for outputs to report mid-test errors and potentially
-// abort the whole test run
+// WithStopRunWithError TODO
+type WithStopRunWithError interface {
+	Output
+	SetStopRunWithErrorFunc(func(error))
+}
 
 // WithRunStatusUpdates means the output can receive test run status updates.
 type WithRunStatusUpdates interface {

--- a/output/types.go
+++ b/output/types.go
@@ -80,11 +80,13 @@ type WithThresholds interface {
 	SetThresholds(map[string]stats.Thresholds)
 }
 
-// WithSetStopEngineRunWithError is an output that requires to have function which will be called with an error from
-// the output which should trigger the Engine to stop
-type WithSetStopEngineRunWithError interface {
+// WithTestRunStop is an output that can stop the Engine mid-test, interrupting 
+// the whole test run execution if some internal condition occurs, completely
+// independently from the thresholds. It requires a callback function which 
+// expects an error and triggers the Engine to stop.
+type WithTestRunStop interface {
 	Output
-	SetStopEngineRunWithError(func(error))
+	SetTestRunStopCallback(func(error))
 }
 
 // WithRunStatusUpdates means the output can receive test run status updates.

--- a/output/types.go
+++ b/output/types.go
@@ -80,10 +80,11 @@ type WithThresholds interface {
 	SetThresholds(map[string]stats.Thresholds)
 }
 
-// WithStopRunWithError TODO
-type WithStopRunWithError interface {
+// WithSetStopEngineRunWithError is an output that requires to have function which will be called with an error from
+// the output which should trigger the Engine to stop
+type WithSetStopEngineRunWithError interface {
 	Output
-	SetStopRunWithErrorFunc(func(error))
+	SetStopEngineRunWithError(func(error))
 }
 
 // WithRunStatusUpdates means the output can receive test run status updates.


### PR DESCRIPTION
This does add an interface that can be implemented by other outputs as well.

fixes #1880


TODOs:
- [ ] Figure out a good name. I kept changing what I think this should be called through the writing of this and am not certain I like any of the names much ... I would argue that the best one is `StopExecutionOnOutputSignal` as it makes it more accurate that we will over stop if the output couldn't be started, and that this is a signal from the output to *stop* not just that there was some error. Unfortunately, it's a bit of a mouthful
- [ ] Figure out how to write an integration test of this ... I have tested it manually and it works (and takes 3 minutes to test) but it will be nice to have a full integration test about this.
- [ ] Print which output signaled to close 


Related to the last point,  I decided to have an error be "returned" not just to call some function is so that we can *always* print it in some good known format instead of it being a responsibility of the output.  