### PR TITLE
Support non-TLS HTTP/2 (i.e. H2C)

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -197,6 +197,11 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		MaxIdleConnsPerHost: int(r.Bundle.Options.BatchPerHost.Int64),
 	}
 	_ = http2.ConfigureTransport(transport)
+	http2Transport, err := http2.ConfigureTransports(transport)
+	http2Transport.AllowHTTP = true
+	http2Transport.DialTLS = func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+		return net.Dial(network, addr)
+	}
 
 	cookieJar, err := cookiejar.New(nil)
 	if err != nil {


### PR DESCRIPTION
Http2.0 non-tls patch
Pls help to check if we did sth wrong, thx!

(edited by @na-- - this is the relevant issue: https://github.com/k6io/k6/issues/970)
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/loadimpact/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/loadimpact/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
