### PR TITLE
Pin Codecov bash uploader version and check its hash

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -90,8 +90,6 @@ jobs:
         go-version: [1.16.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -122,9 +120,15 @@ jobs:
           grep -h -v "^mode:" *.coverage >> coverage.txt
           rm -f *.coverage
       - name: Upload coverage to Codecov
+        env:
+          CODECOV_BASH_VERSION: 1.0.1
+          CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
+          curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
+          echo "$CODECOV_BASH_SHA512SUM codecov" | sha512sum -c -
           platform="${{ matrix.platform }}"
-          bash <(curl --fail -s https://codecov.io/bash) -F "${platform%%-*}"
+          bash ./codecov -F "${platform%%-*}"
       - name: Generate coverage HTML report
         run: go tool cover -html=coverage.txt -o coverage.html
       - name: Upload coverage report


### PR DESCRIPTION
After the [recent breach](https://about.codecov.io/security-update/) this seems like the least we should do for now.