### PR TITLE
Fix Fedora link in installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sudo apt-get update
 
 Or delete the repository file if you added it to `/etc/apt/sources.list.d/`.
 
-And for rpm-based ones, delete the repository file in `/etc/yum.repos.d/`. If you followed the [official installation instructions](https://k6.io/docs/getting-started/installation/#red-hat-centos), this should be:
+And for rpm-based ones, delete the repository file in `/etc/yum.repos.d/`. If you followed the [official installation instructions](https://k6.io/docs/getting-started/installation/#fedora-centos), this should be:
 
 ```bash
 sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo


### PR DESCRIPTION
Maybe we shouldn't have used a link with a fragment, but this was recently changed in the docs, so just to update it here.