### PR TITLE
Explicitly disable GPG check for RPM repo metadata

### DIFF
--- a/packaging/k6-rpm-repo.spec
+++ b/packaging/k6-rpm-repo.spec
@@ -1,5 +1,5 @@
 Name:           k6-rpm
-Version:        0.0.1
+Version:        0.0.2
 Release:        1
 Summary:        k6 RPM Repository Configuration
 Group:          System Environment/Base

--- a/packaging/k6-rpm.repo
+++ b/packaging/k6-rpm.repo
@@ -3,5 +3,6 @@ name=k6
 baseurl=https://dl.k6.io/rpm/$basearch
 enabled=1
 gpgcheck=1
+repo_gpgcheck=0
 metadata_expire=1d
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-k6-io


### PR DESCRIPTION
After some investigation, we decided to disable this explicitly to avoid it failing for users who have `repo_gpgcheck` enabled globally.

Our RPM packages are signed, but we're not planning to sign repo metadata since enabling this check is known to [cause](https://bugzilla.redhat.com/show_bug.cgi?id=1768206) [issues](https://bugzilla.redhat.com/show_bug.cgi?id=1636743) and it's not enabled even for main Fedora repositories.