### PR TITLE
Set cloud status to aborted by script on setup/teardown script errors

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/loadimpact/k6/lib"
 	"github.com/loadimpact/k6/lib/metrics"
+	"github.com/loadimpact/k6/lib/types"
 	"github.com/loadimpact/k6/output"
 	"github.com/loadimpact/k6/stats"
 )
@@ -254,7 +255,12 @@ func (e *Engine) startBackgroundProcesses(
 		case err := <-runResult:
 			if err != nil {
 				e.logger.WithError(err).Debug("run: execution scheduler returned an error")
-				e.setRunStatus(lib.RunStatusAbortedSystem)
+				var serr types.ScriptException
+				if errors.As(err, &serr) {
+					e.setRunStatus(lib.RunStatusAbortedScriptError)
+				} else {
+					e.setRunStatus(lib.RunStatusAbortedSystem)
+				}
 			} else {
 				e.logger.Debug("run: execution scheduler terminated")
 				e.setRunStatus(lib.RunStatusFinished)


### PR DESCRIPTION
Previous to this it would've been aborted by system

