### PR TITLE
Update go version at go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loadimpact/k6
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c


### PR DESCRIPTION
According to https://github.com/k6io/k6/pull/1922, k6 seems to support go v1.15 and v1.16 now.
But go.mod is still defined as go 1.14.
So I change it to 1.15.
If I change it to 1.16 , it may not work with v1.15.