### PR TITLE
Fix threshold encoding when marshalling to JSON

### DIFF
--- a/output/json/json.go
+++ b/output/json/json.go
@@ -27,9 +27,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/loadimpact/k6/output"
 	"github.com/loadimpact/k6/stats"
-	"github.com/sirupsen/logrus"
 )
 
 // TODO: add option for emitting proper JSON files (https://github.com/loadimpact/k6/issues/737)
@@ -100,6 +101,8 @@ func (o *Output) Start() error {
 			o.encoder = stdlibjson.NewEncoder(logfile)
 		}
 	}
+
+	o.encoder.SetEscapeHTML(false)
 
 	pf, err := output.NewPeriodicFlusher(flushPeriod, o.flushMetrics)
 	if err != nil {

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -47,7 +47,7 @@ func getValidator(t *testing.T, expected []string) func(io.Reader) {
 				t.Errorf("Read unexpected line number %d, expected only %d entries", i, len(expected))
 				continue
 			}
-			assert.JSONEq(t, expected[i-1], string(s.Bytes()))
+			assert.Equal(t, expected[i-1], string(s.Bytes()))
 		}
 		assert.NoError(t, s.Err())
 		assert.Equal(t, len(expected), i)
@@ -72,7 +72,7 @@ func generateTestMetricSamples(t *testing.T) ([]stats.SampleContainer, func(io.R
 		stats.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: stats.NewSampleTags(map[string]string{"tag3": "val3"})},
 	}
 	expected := []string{
-		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","tainted":null,"thresholds":["rate<0.01", "p(99)<250"],"submetrics":null,"sub":{"name":"","parent":"","suffix":"","tags":null}},"metric":"my_metric1"}`,
+		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","tainted":null,"thresholds":["rate<0.01","p(99)<250"],"submetrics":null,"sub":{"name":"","parent":"","suffix":"","tags":null}},"metric":"my_metric1"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:10Z","value":1,"tags":{"tag1":"val1"}},"metric":"my_metric1"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:10Z","value":2,"tags":{"tag2":"val2"}},"metric":"my_metric1"}`,
 		`{"type":"Metric","data":{"name":"my_metric2","type":"counter","contains":"data","tainted":null,"thresholds":[],"submetrics":null,"sub":{"name":"","parent":"","suffix":"","tags":null}},"metric":"my_metric2"}`,

--- a/stats/thresholds_test.go
+++ b/stats/thresholds_test.go
@@ -241,6 +241,13 @@ func TestThresholdsJSON(t *testing.T) {
 			"",
 		},
 		{
+			`["rate<0.01"]`,
+			[]string{"rate<0.01"},
+			false,
+			types.NullDuration{},
+			`["rate<0.01"]`,
+		},
+		{
 			`["1+1==2","1+1==3"]`,
 			[]string{"1+1==2", "1+1==3"},
 			false,
@@ -296,7 +303,7 @@ func TestThresholdsJSON(t *testing.T) {
 			}
 
 			t.Run("marshal", func(t *testing.T) {
-				data2, err := json.Marshal(ts)
+				data2, err := MarshalJSONWithoutHTMLEscape(ts)
 				assert.NoError(t, err)
 				output := data.JSON
 				if data.outputJSON != "" {


### PR DESCRIPTION
This fixes an encoding issue for thresholds that are marshalled to JSON, recently added to the JSON output in #1886.

[`json.Marshal()`](https://golang.org/pkg/encoding/json/#Marshal) escapes HTML-sensitive characters by default, so `<` is converted to `\u003c`, `>` to `\u003e`, etc.

We missed it in our tests since they also relied on this behavior which obscures the wrong encoding, but you can see it if you checkout af1e032e and run `go run main.go run -o json=- ./samples/thresholds.js`. The `http_req_duration` metric will be rendered as:

```
{"type":"Metric","data":{"name":"http_req_duration","type":"trend","contains":"time","tainted":null,"thresholds":["p(95)\u003c500"],"submetrics":null,"sub":{"name":"","parent":"","suffix":"","tags":null}},"metric":"http_req_duration"}
```

Whereas on this branch it's rendered properly:

```
{"type":"Metric","data":{"name":"http_req_duration","type":"trend","contains":"time","tainted":null,"thresholds":["p(95)<500"],"submetrics":null,"sub":{"name":"","parent":"","suffix":"","tags":null}},"metric":"http_req_duration"}
```

We should probably merge this before releasing v0.32.0.