### PR TITLE
Safer newline stripping when marshalling to JSON

### DIFF
--- a/stats/thresholds.go
+++ b/stats/thresholds.go
@@ -228,9 +228,12 @@ func MarshalJSONWithoutHTMLEscape(t interface{}) ([]byte, error) {
 	encoder.SetEscapeHTML(false)
 	err := encoder.Encode(t)
 	bytes := buffer.Bytes()
-	// Remove the newline appended by Encode() :-/
-	// See https://github.com/golang/go/issues/37083
-	return bytes[:len(bytes)-1], err
+	if err == nil && len(bytes) > 0 {
+		// Remove the newline appended by Encode() :-/
+		// See https://github.com/golang/go/issues/37083
+		bytes = bytes[:len(bytes)-1]
+	}
+	return bytes, err
 }
 
 var _ json.Unmarshaler = &Thresholds{}


### PR DESCRIPTION
This avoids a potential `slice bounds out of range` panic.