### PR TITLE
Make the windows version info only for windows

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -185,6 +185,7 @@ jobs:
           # Need a blank versioninfo.json for the CLI overrides to work.
           echo '{}' > versioninfo.json
           goversioninfo -64 \
+            -platform-specific=true \
             -charset="1200" \
             -company="Load Impact AB" \
             -copyright="© Load Impact AB. Licensed under AGPL." \


### PR DESCRIPTION
Previously this would've been embedded in *all* binaries as go didn't
know that it shouldn't. This looks to have had no impact, but with the
addition of macos + arm64 binaries we found it as that platform doesn't
support embedding of the specific generate file.
