### PR TITLE
Make request timeout error message lowercase for consistency 

### DIFF
--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -1036,7 +1036,7 @@ func TestDNSResolver(t *testing.T) {
 
 		expErr := sr(`dial tcp 127.0.0.254:HTTPBIN_PORT: connect: connection refused`)
 		if runtime.GOOS == "windows" {
-			expErr = "Request timeout"
+			expErr = "request timeout"
 		}
 		for name, tc := range testCases {
 			tc := tc

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -326,7 +326,7 @@ func TestRequestAndBatch(t *testing.T) {
 			`))
 			endTime := time.Now()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Request timeout")
+			assert.Contains(t, err.Error(), "request timeout")
 			assert.WithinDuration(t, startTime.Add(1*time.Second), endTime, 2*time.Second)
 
 			logEntry := hook.LastEntry()
@@ -344,7 +344,7 @@ func TestRequestAndBatch(t *testing.T) {
 			`))
 			endTime := time.Now()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Request timeout")
+			assert.Contains(t, err.Error(), "request timeout")
 			assert.WithinDuration(t, startTime.Add(1*time.Second), endTime, 2*time.Second)
 
 			logEntry := hook.LastEntry()

--- a/lib/netext/httpext/error_codes.go
+++ b/lib/netext/httpext/error_codes.go
@@ -97,7 +97,7 @@ const (
 	http2ConnectionErrorCodeMsg = "http2: connection error with http2 ErrCode %s"
 	x509HostnameErrorCodeMsg    = "x509: certificate doesn't match hostname"
 	x509UnknownAuthority        = "x509: unknown authority"
-	requestTimeoutErrorCodeMsg  = "Request timeout"
+	requestTimeoutErrorCodeMsg  = "request timeout"
 )
 
 func http2ErrCodeOffset(code http2.ErrCode) errCode {


### PR DESCRIPTION
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/k6io/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/k6io/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->

This is a follow up  to https://github.com/k6io/k6/pull/2008 - addresses comment on consistent capitalization 
