### PR TITLE
Don't panic on binaryResponses where the body wasn't set

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -2212,3 +2212,15 @@ func TestDigestAuthWithBody(t *testing.T) {
 	assertRequestMetricsEmitted(t, sampleContainers[0:1], "POST", urlRaw, urlRaw, 401, "")
 	assertRequestMetricsEmitted(t, sampleContainers[1:2], "POST", urlRaw, urlRaw, 200, "")
 }
+
+func TestBinaryResponseWithStatus0(t *testing.T) {
+	t.Parallel()
+	_, state, _, rt, _ := newRuntime(t) //nolint:dogsled
+	state.Options.Throw = null.BoolFrom(false)
+	_, err := rt.RunString(`
+		var res = http.get("https://asdajkdahdqiuwhejkasdnakjdnadasdlkas.com", { responseType: "binary" });
+		if (res.status !== 0) { throw new Error("wrong status: " + res.status); }
+		if (res.body !== null) { throw new Error("wrong body: " + JSON.stringify(res.body)); }
+	`)
+	require.NoError(t, err)
+}

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -60,7 +60,7 @@ func (j jsonError) Error() string {
 // respType. This is done here instead of in httpext.readResponseBody to avoid
 // a reverse dependency on js/common or goja.
 func processResponse(ctx context.Context, resp *httpext.Response, respType httpext.ResponseType) {
-	if respType == httpext.ResponseTypeBinary {
+	if respType == httpext.ResponseTypeBinary && resp.Body != nil {
 		rt := common.GetRuntime(ctx)
 		resp.Body = rt.NewArrayBuffer(resp.Body.([]byte))
 	}


### PR DESCRIPTION
This panic was still caught and didn't abort the whole k6 just the
current iteration.
