### PR TITLE
Error refactoring and exit code fixes

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -80,8 +80,9 @@ An archive is a fully self-contained test run, and can be executed identically e
 				return err
 			}
 
-			if _, cerr := deriveAndValidateConfig(conf, r.IsExecutable); cerr != nil {
-				return ExitCode{error: cerr, Code: invalidConfigErrorCode}
+			_, err = deriveAndValidateConfig(conf, r.IsExecutable)
+			if err != nil {
+				return err
 			}
 
 			err = r.SetOptions(conf.Options)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -327,7 +327,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 
 			if testProgress == nil {
 				//nolint:stylecheck,golint
-				return errext.WithExitCode(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
+				return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
 			}
 
 			valueColor := getColor(noColor || !stdoutTTY, color.FgCyan)
@@ -336,7 +336,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
 				// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
 				//nolint:stylecheck,golint
-				return errext.WithExitCode(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
+				return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
 			}
 
 			return nil

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -44,14 +44,6 @@ func must(err error) {
 	}
 }
 
-// ExitCode wraps the error with an exit code.
-// Hint is used to show details information about underlying error.
-type ExitCode struct {
-	error
-	Code int
-	Hint string
-}
-
 //TODO: refactor the CLI config so these functions aren't needed - they
 // can mask errors by failing only at runtime, not at compile time
 func getNullBool(flags *pflag.FlagSet, key string) null.Bool {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -171,7 +171,7 @@ func readEnvConfig() (Config, error) {
 // TODO: add better validation, more explicit default values and improve consistency between formats
 // TODO: accumulate all errors and differentiate between the layers?
 func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf Config, err error) {
-	// TODO: use errext.WithExitCode(err, exitcodes.InvalidConfig) where it makes sense?
+	// TODO: use errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig) where it makes sense?
 
 	fileConf, _, err := readDiskConfig(fs)
 	if err != nil {
@@ -232,7 +232,7 @@ func deriveAndValidateConfig(conf Config, isExecutable func(string) bool) (resul
 	if err == nil {
 		err = validateConfig(result, isExecutable)
 	}
-	return result, errext.WithExitCode(err, exitcodes.InvalidConfig)
+	return result, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
 }
 
 func validateConfig(conf Config, isExecutable func(string) bool) error {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
 
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
 	"go.k6.io/k6/lib/testutils"
@@ -177,6 +179,9 @@ func TestDeriveAndValidateConfig(t *testing.T) {
 			_, err := deriveAndValidateConfig(tc.conf,
 				func(_ string) bool { return tc.isExec })
 			if tc.err != "" {
+				var ecerr errext.HasExitCode
+				assert.ErrorAs(t, err, &ecerr)
+				assert.Equal(t, exitcodes.InvalidConfig, ecerr.ExitCode())
 				assert.Contains(t, err.Error(), tc.err)
 			} else {
 				assert.NoError(t, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -186,12 +186,6 @@ func Execute() {
 			exitCode = int(ecerr.ExitCode())
 		}
 
-		hint := ""
-		var herr errext.HasHint
-		if errors.As(err, &herr) {
-			hint = herr.Hint()
-		}
-
 		errText := err.Error()
 		var xerr errext.Exception
 		if errors.As(err, &xerr) {
@@ -199,8 +193,9 @@ func Execute() {
 		}
 
 		fields := logrus.Fields{}
-		if hint != "" {
-			fields["hint"] = hint
+		var herr errext.HasHint
+		if errors.As(err, &herr) {
+			fields["hint"] = herr.Hint()
 		}
 
 		logger.WithFields(fields).Error(errText)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -248,7 +248,7 @@ a commandline interface for interacting with it.`,
 			engineRun, engineWait, err := engine.Init(globalCtx, runCtx)
 			if err != nil {
 				// Add a generic engine exit code if we don't have a more specific one
-				return errext.WithExitCode(err, exitcodes.GenericEngine)
+				return errext.WithExitCodeIfNone(err, exitcodes.GenericEngine)
 			}
 
 			// Init has passed successfully, so unless disabled, make sure we send a
@@ -271,7 +271,7 @@ a commandline interface for interacting with it.`,
 			// Start the test run
 			initBar.Modify(pb.WithConstProgress(0, "Starting test..."))
 			if err := engineRun(); err != nil {
-				return errext.WithExitCode(err, exitcodes.GenericEngine)
+				return errext.WithExitCodeIfNone(err, exitcodes.GenericEngine)
 			}
 			runCancel()
 			logger.Debug("Engine run terminated cleanly")
@@ -321,7 +321,7 @@ a commandline interface for interacting with it.`,
 			engineWait()
 			logger.Debug("Everything has finished, exiting k6!")
 			if engine.IsTainted() {
-				return errext.WithExitCode(errors.New("some thresholds have failed"), exitcodes.ThresholdsHaveFailed)
+				return errext.WithExitCodeIfNone(errors.New("some thresholds have failed"), exitcodes.ThresholdsHaveFailed)
 			}
 			return nil
 		},

--- a/core/engine.go
+++ b/core/engine.go
@@ -30,9 +30,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v3"
 
+	"go.k6.io/k6/errext"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/output"
 	"go.k6.io/k6/stats"
 )
@@ -255,7 +255,7 @@ func (e *Engine) startBackgroundProcesses(
 		case err := <-runResult:
 			if err != nil {
 				e.logger.WithError(err).Debug("run: execution scheduler returned an error")
-				var serr types.ScriptException
+				var serr errext.Exception
 				if errors.As(err, &serr) {
 					e.setRunStatus(lib.RunStatusAbortedScriptError)
 				} else {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -35,6 +35,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/core/local"
+	"go.k6.io/k6/errext"
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
@@ -762,7 +763,7 @@ func TestSetupException(t *testing.T) {
 		t.Fatal("Test timed out")
 	case err := <-errC:
 		require.Error(t, err)
-		var exception types.ScriptException
+		var exception errext.Exception
 		require.ErrorAs(t, err, &exception)
 		require.Equal(t, "Error: baz\n\tat baz (file:///bar.js:7:8(4))\n"+
 			"\tat file:///bar.js:4:5(3)\n\tat setup (file:///script.js:7:204(4))\n",

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"go.k6.io/k6/errext"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/stats"
 	"go.k6.io/k6/ui/pb"
@@ -161,7 +162,7 @@ func (e *ExecutionScheduler) initVU(
 	vuID := e.state.GetUniqueVUIdentifier()
 	vu, err := e.runner.NewVU(int64(vuID), samplesOut)
 	if err != nil {
-		return nil, fmt.Errorf("error while initializing VU #%d: '%s'", vuID, err)
+		return nil, errext.WithHint(err, fmt.Sprintf("error while initializing VU #%d", vuID))
 	}
 
 	logger.Debugf("Initialized VU #%d", vuID)
@@ -273,7 +274,7 @@ func (e *ExecutionScheduler) Init(ctx context.Context, samplesOut chan<- stats.S
 		executorConfig := exec.GetConfig()
 
 		if err := exec.Init(ctx); err != nil {
-			return fmt.Errorf("error while initializing executor %s: %s", executorConfig.GetName(), err)
+			return fmt.Errorf("error while initializing executor %s: %w", executorConfig.GetName(), err)
 		}
 		logger.Debugf("Initialized executor %s", executorConfig.GetName())
 	}

--- a/errext/errext_test.go
+++ b/errext/errext_test.go
@@ -48,7 +48,7 @@ func TestErrextHelpers(t *testing.T) {
 
 	const testExitCode ExitCode = 13
 	assert.Nil(t, WithHint(nil, "test hint"))
-	assert.Nil(t, WithExitCode(nil, testExitCode))
+	assert.Nil(t, WithExitCodeIfNone(nil, testExitCode))
 
 	errBase := errors.New("base error")
 	errBaseWithHint := WithHint(errBase, "test hint")
@@ -59,11 +59,11 @@ func TestErrextHelpers(t *testing.T) {
 	errWrapperWithHints := fmt.Errorf("wrapper error: %w", errBaseWithTwoHints)
 	assertHasHint(t, errWrapperWithHints, "better hint (test hint)")
 
-	errWithExitCode := WithExitCode(errWrapperWithHints, testExitCode)
+	errWithExitCode := WithExitCodeIfNone(errWrapperWithHints, testExitCode)
 	assertHasHint(t, errWithExitCode, "better hint (test hint)")
 	assertHasExitCode(t, errWithExitCode, testExitCode)
 
-	errWithExitCodeAgain := WithExitCode(errWithExitCode, ExitCode(27))
+	errWithExitCodeAgain := WithExitCodeIfNone(errWithExitCode, ExitCode(27))
 	assertHasHint(t, errWithExitCodeAgain, "better hint (test hint)")
 	assertHasExitCode(t, errWithExitCodeAgain, testExitCode)
 

--- a/errext/errext_test.go
+++ b/errext/errext_test.go
@@ -1,0 +1,77 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errext
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertHasHint(t *testing.T, err error, hint string) {
+	var typederr HasHint
+	require.ErrorAs(t, err, &typederr)
+	assert.Equal(t, typederr.Hint(), hint)
+	assert.Contains(t, err.Error(), typederr.Error())
+}
+
+func assertHasExitCode(t *testing.T, err error, exitcode ExitCode) {
+	var typederr HasExitCode
+	require.ErrorAs(t, err, &typederr)
+	assert.Equal(t, typederr.ExitCode(), exitcode)
+	assert.Contains(t, err.Error(), typederr.Error())
+}
+
+func TestErrextHelpers(t *testing.T) {
+	t.Parallel()
+
+	const testExitCode ExitCode = 13
+	assert.Nil(t, WithHint(nil, "test hint"))
+	assert.Nil(t, WithExitCode(nil, testExitCode))
+
+	errBase := errors.New("base error")
+	errBaseWithHint := WithHint(errBase, "test hint")
+	assertHasHint(t, errBaseWithHint, "test hint")
+	errBaseWithTwoHints := WithHint(errBaseWithHint, "better hint")
+	assertHasHint(t, errBaseWithTwoHints, "better hint (test hint)")
+
+	errWrapperWithHints := fmt.Errorf("wrapper error: %w", errBaseWithTwoHints)
+	assertHasHint(t, errWrapperWithHints, "better hint (test hint)")
+
+	errWithExitCode := WithExitCode(errWrapperWithHints, testExitCode)
+	assertHasHint(t, errWithExitCode, "better hint (test hint)")
+	assertHasExitCode(t, errWithExitCode, testExitCode)
+
+	errWithExitCodeAgain := WithExitCode(errWithExitCode, ExitCode(27))
+	assertHasHint(t, errWithExitCodeAgain, "better hint (test hint)")
+	assertHasExitCode(t, errWithExitCodeAgain, testExitCode)
+
+	errBaseWithThreeHints := WithHint(errWithExitCodeAgain, "best hint")
+	assertHasHint(t, errBaseWithThreeHints, "best hint (better hint (test hint))")
+
+	finalErrorMess := fmt.Errorf("woot: %w", errBaseWithThreeHints)
+	assert.Equal(t, finalErrorMess.Error(), "woot: wrapper error: base error")
+	assertHasHint(t, finalErrorMess, "best hint (better hint (test hint))")
+	assertHasExitCode(t, finalErrorMess, testExitCode)
+}

--- a/errext/exception.go
+++ b/errext/exception.go
@@ -1,0 +1,29 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package errext contains extensions for normal Go errors that are used in k6.
+package errext
+
+// Exception represents errors that resulted from a script exception and contain
+// a stack trace that lead to them.
+type Exception interface {
+	error
+	StackTrace() string
+}

--- a/errext/exit_code.go
+++ b/errext/exit_code.go
@@ -1,0 +1,66 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errext
+
+import "errors"
+
+// ExitCode is the code with which the application should exit if this error
+// bubbles up to the top of the scope. Values should be between 0 and 125:
+// https://unix.stackexchange.com/questions/418784/what-is-the-min-and-max-values-of-exit-codes-in-linux
+type ExitCode uint8
+
+// HasExitCode is a wrapper around an error with an attached exit code.
+type HasExitCode interface {
+	error
+	ExitCode() ExitCode
+}
+
+// WithExitCode can attach an exit code to the given error, if it doesn't have
+// one already. It won't do anything if the error already had an exit code
+// attached. Similarly, if there is no error (i.e. the given error is nil), it
+// also won't do anything.
+func WithExitCode(err error, exitCode ExitCode) error {
+	if err == nil {
+		// No error, do nothing
+		return nil
+	}
+	var ecerr HasExitCode
+	if errors.As(err, &ecerr) {
+		// The given error already has an exit code, do nothing
+		return err
+	}
+	return withExitCode{err, exitCode}
+}
+
+type withExitCode struct {
+	error
+	exitCode ExitCode
+}
+
+func (wh withExitCode) Unwrap() error {
+	return wh.error
+}
+
+func (wh withExitCode) ExitCode() ExitCode {
+	return wh.exitCode
+}
+
+var _ HasExitCode = withExitCode{}

--- a/errext/exit_code.go
+++ b/errext/exit_code.go
@@ -33,11 +33,11 @@ type HasExitCode interface {
 	ExitCode() ExitCode
 }
 
-// WithExitCode can attach an exit code to the given error, if it doesn't have
-// one already. It won't do anything if the error already had an exit code
+// WithExitCodeIfNone can attach an exit code to the given error, if it doesn't
+// have one already. It won't do anything if the error already had an exit code
 // attached. Similarly, if there is no error (i.e. the given error is nil), it
 // also won't do anything.
-func WithExitCode(err error, exitCode ExitCode) error {
+func WithExitCodeIfNone(err error, exitCode ExitCode) error {
 	if err == nil {
 		// No error, do nothing
 		return nil

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -1,0 +1,39 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package exitcodes contains the constants representing possible k6 exit error codes.
+//nolint: golint
+package exitcodes
+
+import "go.k6.io/k6/errext"
+
+const (
+	CloudTestRunFailed       errext.ExitCode = 97 // This used to be 99 before k6 v0.33.0
+	CloudFailedToGetProgress errext.ExitCode = 98
+	ThresholdsHaveFailed     errext.ExitCode = 99
+	SetupTimeout             errext.ExitCode = 100
+	TeardownTimeout          errext.ExitCode = 101
+	GenericTimeout           errext.ExitCode = 102 // TODO: remove?
+	GenericEngine            errext.ExitCode = 103
+	InvalidConfig            errext.ExitCode = 104
+	ExternalAbort            errext.ExitCode = 105
+	CannotStartRESTAPI       errext.ExitCode = 106
+	ScriptException          errext.ExitCode = 107
+)

--- a/errext/hint.go
+++ b/errext/hint.go
@@ -36,13 +36,7 @@ type HasHint interface {
 // "new hint (old hint)".
 func WithHint(err error, hint string) error {
 	if err == nil {
-		// No error, do nothing
-		return nil
-	}
-	var oldhint HasHint
-	if errors.As(err, &oldhint) {
-		// The given error already had a hint, wrap it
-		hint = hint + " (" + oldhint.Hint() + ")"
+		return nil // No error, do nothing
 	}
 	return withHint{err, hint}
 }
@@ -57,7 +51,14 @@ func (wh withHint) Unwrap() error {
 }
 
 func (wh withHint) Hint() string {
-	return wh.hint
+	hint := wh.hint
+	var oldhint HasHint
+	if errors.As(wh.error, &oldhint) {
+		// The given error already had a hint, wrap it
+		hint = hint + " (" + oldhint.Hint() + ")"
+	}
+
+	return hint
 }
 
 var _ HasHint = withHint{}

--- a/errext/hint.go
+++ b/errext/hint.go
@@ -1,0 +1,63 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errext
+
+import "errors"
+
+// HasHint is a wrapper around an error with an attached user hint. These hints
+// can be used to give extra human-readable information about the error,
+// including suggestions on how the error can be fixed.
+type HasHint interface {
+	error
+	Hint() string
+}
+
+// WithHint is a helper that can attach a hint to the given error. If there is
+// no error (i.e. the given error is nil), it won't do anything. If the given
+// error already had a hint, this helper will wrap it so that the new hint is
+// "new hint (old hint)".
+func WithHint(err error, hint string) error {
+	if err == nil {
+		// No error, do nothing
+		return nil
+	}
+	var oldhint HasHint
+	if errors.As(err, &oldhint) {
+		// The given error already had a hint, wrap it
+		hint = hint + " (" + oldhint.Hint() + ")"
+	}
+	return withHint{err, hint}
+}
+
+type withHint struct {
+	error
+	hint string
+}
+
+func (wh withHint) Unwrap() error {
+	return wh.error
+}
+
+func (wh withHint) Hint() string {
+	return wh.hint
+}
+
+var _ HasHint = withHint{}

--- a/js/runner.go
+++ b/js/runner.go
@@ -741,7 +741,11 @@ type scriptException struct {
 	inner *goja.Exception
 }
 
-var _ errext.Exception = &scriptException{}
+var (
+	_ errext.Exception   = &scriptException{}
+	_ errext.HasExitCode = &scriptException{}
+	_ errext.HasHint     = &scriptException{}
+)
 
 func (s *scriptException) Error() string {
 	// this calls String instead of error so that by default if it's printed to print the stacktrace

--- a/js/timeout_error_test.go
+++ b/js/timeout_error_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package lib
+package js
 
 import (
 	"strings"
@@ -29,6 +29,7 @@ import (
 )
 
 func TestTimeoutError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		stage, expectedStrContain string
 		d                         time.Duration
@@ -39,14 +40,15 @@ func TestTimeoutError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		te := NewTimeoutError(tc.stage, tc.d)
-		if !strings.Contains(te.String(), tc.expectedStrContain) {
-			t.Errorf("Expected error contains %s, but got: %s", tc.expectedStrContain, te.String())
+		te := newTimeoutError(tc.stage, tc.d)
+		if !strings.Contains(te.Error(), tc.expectedStrContain) {
+			t.Errorf("Expected error contains %s, but got: %s", tc.expectedStrContain, te.Error())
 		}
 	}
 }
 
 func TestTimeoutErrorHint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		stage string
 		empty bool
@@ -57,7 +59,7 @@ func TestTimeoutErrorHint(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		te := NewTimeoutError(tc.stage, time.Second)
+		te := newTimeoutError(tc.stage, time.Second)
 		if tc.empty && te.Hint() != "" {
 			t.Errorf("Expected empty hint, got: %s", te.Hint())
 		}

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"go.k6.io/k6/errext"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/ui/pb"
@@ -97,7 +98,7 @@ func getIterationRunner(
 			return false
 		default:
 			if err != nil {
-				var exception types.ScriptException
+				var exception errext.Exception
 				if errors.As(err, &exception) {
 					// TODO don't count this as a full iteration?
 					logger.WithField("source", "stacktrace").Error(exception.StackTrace())

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -280,10 +280,3 @@ func GetDurationValue(v interface{}) (time.Duration, error) {
 		return time.Duration(n) * time.Millisecond, nil
 	}
 }
-
-// ScriptException is an interface used to represent an error as a result of a script exception.
-type ScriptException interface {
-	error
-	// StackTrace is the string representation of the stacktrace of where the script exception happened
-	StackTrace() string
-}


### PR DESCRIPTION
This PR does a few things:
- refactors (and I think simplifies) a bunch of error handling and exit code determination
- fixes the bug of k6 returning an exit code of `103` for script errors in `VU>0` initialization, while preserving the helpful hints
- (breaking change) changes one `k6 cloud` exit code from 99 to 97, to make it distinct from the already existing `99` exit code for `k6 run` (the k6 cloud code doesn't always mean that the thresholds have failed)