### PR TITLE
Fix array encoding in form data requests

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -177,7 +177,7 @@ func (h *HTTP) parseRequest(
 		if !requestContainsFile(data) {
 			bodyQuery := make(url.Values, len(data))
 			for k, v := range data {
-				switch reflect.TypeOf(v).Kind() {
+				switch reflect.TypeOf(v).Kind() { //nolint:exhaustive
 				// handle json arrays in params
 				case reflect.Slice, reflect.Array:
 					s := reflect.ValueOf(v)

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -177,16 +177,13 @@ func (h *HTTP) parseRequest(
 		if !requestContainsFile(data) {
 			bodyQuery := make(url.Values, len(data))
 			for k, v := range data {
-				switch reflect.TypeOf(v).Kind() { //nolint:exhaustive
-				// handle json arrays in params
-				case reflect.Slice, reflect.Array:
-					s := reflect.ValueOf(v)
-					for i := 0; i < s.Len(); i++ {
-						bodyQuery.Add(k, formatFormVal(s.Index(i)))
+				if arr, ok := v.([]interface{}); ok {
+					for _, el := range arr {
+						bodyQuery.Add(k, formatFormVal(el))
 					}
-				default:
-					bodyQuery.Set(k, formatFormVal(v))
+					continue
 				}
+				bodyQuery.Set(k, formatFormVal(v))
 			}
 			result.Body = bytes.NewBufferString(bodyQuery.Encode())
 			result.Req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -177,7 +177,16 @@ func (h *HTTP) parseRequest(
 		if !requestContainsFile(data) {
 			bodyQuery := make(url.Values, len(data))
 			for k, v := range data {
-				bodyQuery.Set(k, formatFormVal(v))
+				switch reflect.TypeOf(v).Kind() {
+				// handle json arrays in params
+				case reflect.Slice, reflect.Array:
+					s := reflect.ValueOf(v)
+					for i := 0; i < s.Len(); i++ {
+						bodyQuery.Add(k, formatFormVal(s.Index(i)))
+					}
+				default:
+					bodyQuery.Set(k, formatFormVal(v))
+				}
 			}
 			result.Body = bytes.NewBufferString(bodyQuery.Encode())
 			result.Req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1226,10 +1226,14 @@ func TestRequestAndBatch(t *testing.T) {
 
 			t.Run("object", func(t *testing.T) {
 				_, err := rt.RunString(fmt.Sprintf(sr(`
-				var res = http.%s("HTTPBIN_URL/%s", {a: "a", b: 2});
+				var equalArray = function(a, b) {
+					return a.length === b.length && a.every(function(v, i) { return v === b[i]});
+				}
+				var res = http.%s("HTTPBIN_URL/%s", {a: "a", b: 2, c: ["one", "two"]});
 				if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 				if (res.json().form.a != "a") { throw new Error("wrong a=: " + res.json().form.a); }
 				if (res.json().form.b != "2") { throw new Error("wrong b=: " + res.json().form.b); }
+				if (!equalArray(res.json().form.c, ["one", "two"])) { throw new Error("wrong c: " + res.json().form.c); }
 				if (res.json().headers["Content-Type"] != "application/x-www-form-urlencoded") { throw new Error("wrong content type: " + res.json().headers["Content-Type"]); }
 				`), fn, strings.ToLower(method)))
 				assert.NoError(t, err)


### PR DESCRIPTION
This is a continuation of #1754, with an added check for the correct encoding and disabling of the `exhaustive` linter, since it doesn't seem like we can avoid the reflection.

Closes #1713