### PR TITLE
Fix wrong regexps for loaders

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -52,8 +52,8 @@ var (
 		fn   loaderFunc
 		expr *regexp.Regexp
 	}{
-		{"cdnjs", cdnjs, regexp.MustCompile(`^cdnjs.com/libraries/([^/]+)(?:/([(\d\.)]+-?[^/]*))?(?:/(.*))?$`)},
-		{"github", github, regexp.MustCompile(`^github.com/([^/]+)/([^/]+)/(.*)$`)},
+		{"cdnjs", cdnjs, regexp.MustCompile(`^cdnjs\.com/libraries/([^/]+)(?:/([(\d\.)]+-?[^/]*))?(?:/(.*))?$`)},
+		{"github", github, regexp.MustCompile(`^github\.com/([^/]+)/([^/]+)/(.*)$`)},
 	}
 	httpsSchemeCouldntBeLoadedMsg = `The moduleSpecifier "%s" couldn't be retrieved from` +
 		` the resolved url "%s". Error : "%s"`


### PR DESCRIPTION
Those were detected by CodeQL (https://github.com/k6io/k6/pull/1961)