### PR TITLE
Fix unlikely data race when calling BaseExecutor methods

### DIFF
--- a/lib/executor/base_executor.go
+++ b/lib/executor/base_executor.go
@@ -79,29 +79,29 @@ func (bs *BaseExecutor) Init(_ context.Context) error {
 }
 
 // GetConfig returns the configuration with which this executor was launched.
-func (bs BaseExecutor) GetConfig() lib.ExecutorConfig {
+func (bs *BaseExecutor) GetConfig() lib.ExecutorConfig {
 	return bs.config
 }
 
 // getNextLocalVUID increments and returns the next VU ID that's specific for
 // this executor (i.e. not global like __VU).
-func (bs BaseExecutor) getNextLocalVUID() uint64 {
+func (bs *BaseExecutor) getNextLocalVUID() uint64 {
 	return atomic.AddUint64(bs.VUIDLocal, 1)
 }
 
 // GetLogger returns the executor logger entry.
-func (bs BaseExecutor) GetLogger() *logrus.Entry {
+func (bs *BaseExecutor) GetLogger() *logrus.Entry {
 	return bs.logger
 }
 
 // GetProgress just returns the progressbar pointer.
-func (bs BaseExecutor) GetProgress() *pb.ProgressBar {
+func (bs *BaseExecutor) GetProgress() *pb.ProgressBar {
 	return bs.progress
 }
 
 // getMetricTags returns a tag set that can be used to emit metrics by the
 // executor. The VU ID is optional.
-func (bs BaseExecutor) getMetricTags(vuID *uint64) *stats.SampleTags {
+func (bs *BaseExecutor) getMetricTags(vuID *uint64) *stats.SampleTags {
 	tags := bs.executionState.Options.RunTags.CloneTags()
 	if bs.executionState.Options.SystemTags.Has(stats.TagScenario) {
 		tags["scenario"] = bs.config.GetName()


### PR DESCRIPTION
Calling these methods defined on a value receiver copies the BaseExecutor instance and could cause a data race if another goroutine is writing to it. In practice this wasn't a problem and unlikely anyone would ever run into it on `master`, but it did appear on the `feat/1320-execution-api` branch (#1863) when running:

```
go run -race main.go run --quiet -u 5 -i 5 'github.com/k6io/k6/samples/http_get.js'
```

Clipped stack trace:

```
WARNING: DATA RACE
Write at 0x00c00050d7a8 by main goroutine:
  go.k6.io/k6/lib/executor.(*SharedIterations).Init()
      /home/ivan/Projects/k6io/k6/lib/executor/shared_iterations.go:179 +0x384
  go.k6.io/k6/core/local.(*ExecutionScheduler).Init()
      /home/ivan/Projects/k6io/k6/core/local/local.go:276 +0xc1c
  go.k6.io/k6/core.(*Engine).Init()
      /home/ivan/Projects/k6io/k6/core/engine.go:190 +0x148
  go.k6.io/k6/cmd.getRunCmd.func1()
      /home/ivan/Projects/k6io/k6/cmd/run.go:248 +0x1ad7
...

Previous read at 0x00c00050d7a8 by goroutine 32:
  go.k6.io/k6/lib/executor.(*SharedIterations).GetProgress()
      <autogenerated>:1 +0x85
  go.k6.io/k6/cmd.getRunCmd.func1.1()
      /home/ivan/Projects/k6io/k6/cmd/run.go:180 +0x13d
```

Also see https://github.com/k6io/k6/pull/1863#discussion_r652612344 .

(I didn't base this on `master` as I would need to rebase #1863 again and we all dislike the GH reference spam in issues :sweat_smile:, and I would have to do this on #1863 anyway for the newly added methods.)