### PR TITLE
Make `metric.getName()` into `metric.name`

### DIFF
--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -65,15 +65,13 @@ func newMetric(ctxPtr *context.Context, name string, t stats.MetricType, isTime 
 	}
 
 	rt := common.GetRuntime(*ctxPtr)
-	binded := common.Bind(rt, Metric{stats.New(name, t, valueType)}, ctxPtr)
+	bound := common.Bind(rt, Metric{stats.New(name, t, valueType)}, ctxPtr)
 	o := rt.NewObject()
-	err := o.DefineAccessorProperty("name", rt.ToValue(func() interface{} {
-		return name
-	}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE)
+	err := o.DefineDataProperty("name", rt.ToValue(name), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE)
 	if err != nil {
 		return nil, err
 	}
-	if err = o.Set("add", rt.ToValue(binded["add"])); err != nil {
+	if err = o.Set("add", rt.ToValue(bound["add"])); err != nil {
 		return nil, err
 	}
 	return o, nil

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -67,10 +67,15 @@ func newMetric(ctxPtr *context.Context, name string, t stats.MetricType, isTime 
 	rt := common.GetRuntime(*ctxPtr)
 	binded := common.Bind(rt, Metric{stats.New(name, t, valueType)}, ctxPtr)
 	o := rt.NewObject()
-	o.DefineAccessorProperty("name", rt.ToValue(func() interface{} {
+	err := o.DefineAccessorProperty("name", rt.ToValue(func() interface{} {
 		return name
 	}), nil, goja.FLAG_FALSE, goja.FLAG_TRUE)
-	o.Set("add", rt.ToValue(binded["add"]))
+	if err != nil {
+		return nil, err
+	}
+	if err = o.Set("add", rt.ToValue(binded["add"])); err != nil {
+		return nil, err
+	}
 	return o, nil
 }
 

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -172,6 +172,23 @@ func TestMetricNames(t *testing.T) {
 
 func TestMetricGetName(t *testing.T) {
 	t.Parallel()
-	metric := Metric{metric: &stats.Metric{Name: "myMetricName"}}
-	assert.Equal(t, "myMetricName", metric.GetName())
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+
+	ctxPtr := new(context.Context)
+	*ctxPtr = common.WithRuntime(context.Background(), rt)
+	rt.Set("metrics", common.Bind(rt, New(), ctxPtr))
+	v, err := rt.RunString(`
+		var m = new metrics.Counter("my_metric")
+		m.name
+	`)
+	require.NoError(t, err)
+	require.Equal(t, "my_metric", v.String())
+
+	_, err = rt.RunString(`
+		"use strict";
+		m.name = "something"
+	`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "TypeError: Cannot assign to read only property 'name'")
 }

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -177,7 +177,7 @@ func TestMetricGetName(t *testing.T) {
 
 	ctxPtr := new(context.Context)
 	*ctxPtr = common.WithRuntime(context.Background(), rt)
-	rt.Set("metrics", common.Bind(rt, New(), ctxPtr))
+	require.NoError(t, rt.Set("metrics", common.Bind(rt, New(), ctxPtr)))
 	v, err := rt.RunString(`
 		var m = new metrics.Counter("my_metric")
 		m.name

--- a/samples/custom_metrics.js
+++ b/samples/custom_metrics.js
@@ -28,7 +28,7 @@ export default function () {
 
     // Add one for number of requests
     myCounter.add(1);
-    console.log(myCounter.getName(), " is config ready")
+    console.log(myCounter.name, " is config ready")
 
     // Set max response time seen
     maxResponseTime = Math.max(maxResponseTime, res.timings.duration);


### PR DESCRIPTION
The original change was proposed in https://github.com/k6io/k6/issues/2053 and implemented in https://github.com/k6io/k6/pull/2058