### PR TITLE
Fix CI process to only depend on tests with latest stable Go

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -57,7 +57,7 @@ jobs:
           echo "Base revision: $BASEREV"
           golangci-lint run --out-format=tab --new-from-rev "$BASEREV" ./...
 
-  test:
+  test-prev:
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
           args=("-p" "2" "-race")
           go test "${args[@]}" -timeout 800s ./...
 
-  test-cov:
+  test-current-cov:
     strategy:
       fail-fast: false
       matrix:
@@ -181,7 +181,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [configure, deps, lint, test, test-cov]
+    needs: [configure, deps, lint, test-current-cov]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}
@@ -242,7 +242,7 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    needs: [deps, lint, test, test-cov, configure]
+    needs: [deps, lint, test-current-cov, configure]
     env:
       VERSION: ${{ needs.configure.outputs.version }}
     steps:
@@ -300,7 +300,7 @@ jobs:
     defaults:
       run:
         shell: powershell
-    needs: [deps, lint, test, test-cov, configure, build]
+    needs: [deps, lint, test-current-cov, configure, build]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}
@@ -369,7 +369,7 @@ jobs:
   # Disabled until #1997 and #1998 are addressed.
   # publish-macos:
   #   runs-on: macos-latest
-  #   needs: [deps, lint, test, test-cov, configure, build]
+  #   needs: [deps, lint, test-current-cov, configure, build]
   #   if: startsWith(github.ref, 'refs/tags/v')
   #   env:
   #     VERSION: ${{ needs.configure.outputs.version }}
@@ -387,7 +387,7 @@ jobs:
 
   publish-github:
     runs-on: ubuntu-latest
-    needs: [configure, deps, lint, test, test-cov, build, package-windows]
+    needs: [configure, deps, lint, test-current-cov, build, package-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}


### PR DESCRIPTION
We don't test with Go 1.15 at the moment because if using go:embed. The test-prev check is still here, but it is disabled and nothing depends on it. This will be the state until Go 1.17 is released and we can switch test-prev to 1.16. And even then, the build probably shouldn't depend on test-prev, its failure should be only informative, not aborting the whole CI.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/k6io/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/k6io/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
