### PR TITLE
lib/options: BlacklistIPs json encoding/decoding

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -28,10 +28,9 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/guregu/null.v3"
-
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/stats"
+	"gopkg.in/guregu/null.v3"
 )
 
 // DefaultScenarioName is used as the default key/ID of the scenario config entries
@@ -178,8 +177,12 @@ func (ipnet *IPNet) UnmarshalText(b []byte) error {
 	}
 
 	*ipnet = *newIPNet
-
 	return nil
+}
+
+// MarshalText encodes the IPNet representation using CIDR notation.
+func (ipnet *IPNet) MarshalText() ([]byte, error) {
+	return []byte(ipnet.String()), nil
 }
 
 // HostAddress stores information about IP and port

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -307,15 +307,28 @@ func TestOptions(t *testing.T) {
 		opts := Options{}.Apply(Options{
 			BlacklistIPs: []*IPNet{{
 				IPNet: net.IPNet{
-					IP:   net.IPv4zero,
-					Mask: net.CIDRMask(1, 1),
+					IP:   net.IPv4bcast,
+					Mask: net.CIDRMask(31, 32),
 				},
 			}},
 		})
 		assert.NotNil(t, opts.BlacklistIPs)
 		assert.NotEmpty(t, opts.BlacklistIPs)
-		assert.Equal(t, net.IPv4zero, opts.BlacklistIPs[0].IP)
-		assert.Equal(t, net.CIDRMask(1, 1), opts.BlacklistIPs[0].Mask)
+		assert.Equal(t, net.IPv4bcast, opts.BlacklistIPs[0].IP)
+		assert.Equal(t, net.CIDRMask(31, 32), opts.BlacklistIPs[0].Mask)
+
+		t.Run("JSON", func(t *testing.T) {
+			t.Parallel()
+
+			b, err := json.Marshal(opts)
+			require.NoError(t, err)
+
+			var uopts Options
+			err = json.Unmarshal(b, &uopts)
+			require.NoError(t, err)
+			require.Len(t, uopts.BlacklistIPs, 1)
+			require.Equal(t, "255.255.255.254/31", uopts.BlacklistIPs[0].String())
+		})
 	})
 	t.Run("BlockedHostnames", func(t *testing.T) {
 		blockedHostnames, err := types.NewNullHostnameTrie([]string{"test.k6.io", "*valid.pattern"})


### PR DESCRIPTION
Support JSON encoding for the `BlacklistIPs` option.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/k6io/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/k6io/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
